### PR TITLE
fix bug in edit appointment command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditAppointmentCommand.java
@@ -94,11 +94,9 @@ public class EditAppointmentCommand extends Command {
             patient = appointmentToEdit.getPatient();
         }
         Appointment editedAppointment = createEditedAppointment(patient, appointmentToEdit, editAppointmentDescriptor);
-        if (appointmentToEdit.hasConflict(editedAppointment)
-                || model.hasConflictingAppointment(editedAppointment)) {
+        if (model.hasConflictingAppointmentExcludingTarget(appointmentToEdit, editedAppointment)) {
             throw new CommandException(MESSAGE_APPOINTMENT_CONFLICT);
         }
-        // if remove the previous line, would result in error here
         model.setAppointment(appointmentToEdit, editedAppointment);
         model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
         return new CommandResult(String.format(MESSAGE_EDIT_APPOINTMENT_SUCCESS, editedAppointment));

--- a/src/main/java/seedu/address/model/AppointmentSchedule.java
+++ b/src/main/java/seedu/address/model/AppointmentSchedule.java
@@ -77,6 +77,15 @@ public class AppointmentSchedule implements ReadOnlyAppointmentSchedule {
     }
 
     /**
+     * Returns true if an appointment has a conflict with {@code appointment} exists
+     * in the appointment schedule.
+     */
+    public boolean hasConflictExcludingTarget(Appointment target, Appointment appointment) {
+        requireNonNull(appointment);
+        return appointments.hasConflictExcludingTarget(target, appointment);
+    }
+
+    /**
      * Adds an appointment to the address book.
      * The appointment must not have conflicts with the existing appointments in the
      * appointment schedule

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -114,6 +114,12 @@ public interface Model {
      * Returns true if an appointment that conflicts with {@code appointment} exists in the appointment schedule.
      */
     boolean hasConflictingAppointment(Appointment appointment);
+
+    /**
+     * Returns true if an appointment that conflicts with {@code appointment}
+     * exists in the appointment schedule excluding the target.
+     */
+    boolean hasConflictingAppointmentExcludingTarget(Appointment target, Appointment appointment);
     /**
      * Deletes the given appointment.
      * The appointment must exist in the appointment schedule.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -177,7 +177,13 @@ public class ModelManager implements Model {
     @Override
     public boolean hasConflictingAppointment(Appointment appointment) {
         requireNonNull(appointment);
-        return appointmentSchedule.hasAppointment(appointment);
+        return appointmentSchedule.hasConflict(appointment);
+    }
+
+    @Override
+    public boolean hasConflictingAppointmentExcludingTarget(Appointment target, Appointment appointment) {
+        requireNonNull(appointment);
+        return appointmentSchedule.hasConflictExcludingTarget(target, appointment);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/appointment/NonConflictingAppointmentList.java
+++ b/src/main/java/seedu/address/model/appointment/NonConflictingAppointmentList.java
@@ -48,6 +48,16 @@ public class NonConflictingAppointmentList implements Iterable<Appointment> {
     }
 
     /**
+     * Returns true if the list contains appointments that are in conflict with {@code toCheck}
+     */
+    public boolean hasConflictExcludingTarget(Appointment toExclude, Appointment toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(appt -> {
+            return toCheck.hasConflict(appt) && !toExclude.equals(appt);
+        });
+    }
+
+    /**
      * Returns true if {@code persons} contains non-conflicting appointments.
      */
     private boolean appointmentsAreNotInConflict(List<Appointment> appointments) {
@@ -98,7 +108,7 @@ public class NonConflictingAppointmentList implements Iterable<Appointment> {
             throw new AppointmentNotFoundException();
         }
 
-        if (hasConflict(editedAppointment)) {
+        if (hasConflictExcludingTarget(target, editedAppointment)) {
             throw new AppointmentConflictException();
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPatientCommandTest.java
@@ -190,6 +190,11 @@ public class AddPatientCommandTest {
         }
 
         @Override
+        public boolean hasConflictingAppointmentExcludingTarget(Appointment target, Appointment appointment) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deleteAppointment(Appointment target) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
- `hasConflictingAppointment()` in EditAppointmentCommand had a bug where it was including the old version of itself (i.e. the unedited version of the appointment) when checking for conflicts
- meant that `edit-appt 1 pt/1` would not work because the old (unedited) version of the appointment was still in the appointment schedule, and `hasConflictingAppointment()` would return `true`,
- solved by writing `hasConflictingAppointmentExcludingTarget()` method, which terminates at `hasConflictExcludingTarget()` in `NonConflictingAppointmentList.java`
- `hasConflictExcludingTarget()` checks that if any conflicting appointments exist, they are not the appointment that is to be excluded.