### PR TITLE
feat: force delete of appointments in delete patient command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/patient/DeletePatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/patient/DeletePatientCommand.java
@@ -33,6 +33,11 @@ public class DeletePatientCommand extends Command {
     private final Index targetIndex;
     private final boolean isForceDelete;
 
+    /**
+     * Constructor: creates a DeletePatientCommand
+     * @param targetIndex index of patient to be deleted
+     * @param isForceDelete true if force delete is required
+     */
     public DeletePatientCommand(Index targetIndex, boolean isForceDelete) {
         this.targetIndex = targetIndex;
         this.isForceDelete = isForceDelete;

--- a/src/main/java/seedu/address/logic/commands/patient/DeletePatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/patient/DeletePatientCommand.java
@@ -31,9 +31,11 @@ public class DeletePatientCommand extends Command {
             + "Example: " + COMMAND_WORD + " --force " + " 1";
 
     private final Index targetIndex;
+    private final boolean isForceDelete;
 
-    public DeletePatientCommand(Index targetIndex) {
+    public DeletePatientCommand(Index targetIndex, boolean isForceDelete) {
         this.targetIndex = targetIndex;
+        this.isForceDelete = isForceDelete;
     }
 
     @Override
@@ -46,6 +48,10 @@ public class DeletePatientCommand extends Command {
         }
 
         Patient patientToDelete = lastShownList.get(targetIndex.getZeroBased());
+
+        if (isForceDelete) {
+            model.deletePatientAppointments(patientToDelete);
+        }
 
         // checks if patient has any existing appointments
         if (model.hasPatientInAppointmentSchedule(patientToDelete)) {

--- a/src/main/java/seedu/address/logic/parser/patient/DeletePatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/patient/DeletePatientCommandParser.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser.patient;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.patient.DeletePatientCommand;
 import seedu.address.logic.parser.Parser;
@@ -14,17 +17,40 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class DeletePatientCommandParser implements Parser<DeletePatientCommand> {
 
     /**
+     * Used for the separation of force delete format and patient index.
+     */
+    private static final Pattern FORCE_DELETE_FORMAT = Pattern.compile("(?<forceDelete>\\D+)(?<patientIndex>.*)");
+
+    /**
      * Parses the given {@code String} of arguments in the context of the DeletePatientCommand
      * and returns a DeletePatientCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeletePatientCommand parse(String args) throws ParseException {
+        final Matcher forceDeleteMatcher = FORCE_DELETE_FORMAT.matcher(args.trim());
+        boolean isForceDelete = false;
+        String indexToParse = args;
+
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeletePatientCommand(index);
+            if (forceDeleteMatcher.matches()) {
+                final String forceDelete = forceDeleteMatcher.group("forceDelete").trim();
+                final String patientIndex = forceDeleteMatcher.group("patientIndex");
+
+                if (forceDelete.equals("--force")) {
+                    isForceDelete = true;
+                    indexToParse = patientIndex;
+                }
+            }
+
+            Index index = ParserUtil.parseIndex(indexToParse);
+
+            return new DeletePatientCommand(index, isForceDelete);
         } catch (ParseException pe) {
+            String messageUsage = isForceDelete ? DeletePatientCommand.FORCE_DELETE_MESSAGE_USAGE
+                    : DeletePatientCommand.MESSAGE_USAGE;
+
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePatientCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, messageUsage), pe);
         }
     }
 

--- a/src/main/java/seedu/address/model/AppointmentSchedule.java
+++ b/src/main/java/seedu/address/model/AppointmentSchedule.java
@@ -69,13 +69,6 @@ public class AppointmentSchedule implements ReadOnlyAppointmentSchedule {
     }
 
     /**
-     * Returns true if a patient has existing appointments in the appointment schedule.
-     */
-    public boolean hasPatientInSchedule(Patient patient) {
-        return appointments.hasPatientInSchedule(patient);
-    }
-
-    /**
      * Returns true if an appointment has a conflict with {@code appointment} exists
      * in the appointment schedule.
      */
@@ -91,6 +84,28 @@ public class AppointmentSchedule implements ReadOnlyAppointmentSchedule {
     public boolean hasConflictExcludingTarget(Appointment target, Appointment appointment) {
         requireNonNull(appointment);
         return appointments.hasConflictExcludingTarget(target, appointment);
+    }
+
+    /**
+     * Returns true if a patient has existing appointments in the appointment schedule.
+     */
+    public boolean hasPatientInSchedule(Patient patient) {
+        return appointments.hasPatientInSchedule(patient);
+    }
+
+    /**
+     * Removes {@code toRemove} from this {@code AppointmentSchedule}.
+     * {@code toRemove} must exist in the appointment schedule.
+     */
+    public void removeAppointment(Appointment toRemove) {
+        appointments.remove(toRemove);
+    }
+
+    /**
+     * Deletes all appointments associated with the input patient from the appointment schedule.
+     */
+    public void deletePatientAppointments(Patient patient) {
+        appointments.deletePatientAppointments(patient);
     }
 
     /**
@@ -114,16 +129,7 @@ public class AppointmentSchedule implements ReadOnlyAppointmentSchedule {
         appointments.setAppointment(target, editedAppointment);
     }
 
-    /**
-     * Removes {@code toRemove} from this {@code AppointmentSchedule}.
-     * {@code toRemove} must exist in the appointment schedule.
-     */
-    public void removeAppointment(Appointment toRemove) {
-        appointments.remove(toRemove);
-    }
-
     //// util methods
-
     @Override
     public String toString() {
         return appointments.asUnmodifiableObservableList().size() + " appointments";

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -111,11 +111,6 @@ public interface Model {
     ReadOnlyAppointmentSchedule getAppointmentSchedule();
 
     /**
-     * Returns true if patient has existing appointments in the appointment schedule.
-     */
-    boolean hasPatientInAppointmentSchedule(Patient patient);
-
-    /**
      * Returns true if an appointment that conflicts with {@code appointment} exists in the appointment schedule.
      */
     boolean hasConflictingAppointment(Appointment appointment);
@@ -127,10 +122,20 @@ public interface Model {
     boolean hasConflictingAppointmentExcludingTarget(Appointment target, Appointment appointment);
 
     /**
+     * Returns true if patient has existing appointments in the appointment schedule.
+     */
+    boolean hasPatientInAppointmentSchedule(Patient patient);
+
+    /**
      * Deletes the given appointment.
      * The appointment must exist in the appointment schedule.
      */
     void deleteAppointment(Appointment target);
+
+    /**
+     * Deletes all appointments associated with the input patient from the appointment schedule.
+     */
+    void deletePatientAppointments(Patient patient);
 
     /**
      * Adds the given appointment.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -176,12 +176,6 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean hasPatientInAppointmentSchedule(Patient patient) {
-        requireNonNull(patient);
-        return appointmentSchedule.hasPatientInSchedule(patient);
-    }
-
-    @Override
     public boolean hasConflictingAppointment(Appointment appointment) {
         requireNonNull(appointment);
         return appointmentSchedule.hasConflict(appointment);
@@ -194,8 +188,20 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasPatientInAppointmentSchedule(Patient patient) {
+        requireNonNull(patient);
+        return appointmentSchedule.hasPatientInSchedule(patient);
+    }
+
+    @Override
     public void deleteAppointment(Appointment target) {
         appointmentSchedule.removeAppointment(target);
+    }
+
+    @Override
+    public void deletePatientAppointments(Patient patient) {
+        requireNonNull(patient);
+        appointmentSchedule.deletePatientAppointments(patient);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/appointment/NonConflictingAppointmentList.java
+++ b/src/main/java/seedu/address/model/appointment/NonConflictingAppointmentList.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -135,6 +136,15 @@ public class NonConflictingAppointmentList implements Iterable<Appointment> {
         }
 
         FXCollections.sort(internalList);
+    }
+
+    /**
+     * Deletes all appointments associated with the input patient from the appointment schedule.
+     */
+    public void deletePatientAppointments(Patient patient) {
+        List<Appointment> PatientAppointmentList = internalList.stream().filter(appointment ->
+                appointment.getPatient().equals(patient)).collect(Collectors.toList());
+        PatientAppointmentList.forEach(appointment -> internalList.remove(appointment));
     }
 
     public void setAppointments(NonConflictingAppointmentList replacement) {

--- a/src/main/java/seedu/address/model/appointment/NonConflictingAppointmentList.java
+++ b/src/main/java/seedu/address/model/appointment/NonConflictingAppointmentList.java
@@ -142,9 +142,9 @@ public class NonConflictingAppointmentList implements Iterable<Appointment> {
      * Deletes all appointments associated with the input patient from the appointment schedule.
      */
     public void deletePatientAppointments(Patient patient) {
-        List<Appointment> PatientAppointmentList = internalList.stream().filter(appointment ->
+        List<Appointment> patientAppointmentList = internalList.stream().filter(appointment ->
                 appointment.getPatient().equals(patient)).collect(Collectors.toList());
-        PatientAppointmentList.forEach(appointment -> internalList.remove(appointment));
+        patientAppointmentList.forEach(appointment -> internalList.remove(appointment));
     }
 
     public void setAppointments(NonConflictingAppointmentList replacement) {

--- a/src/test/java/seedu/address/logic/commands/patient/AddPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/patient/AddPatientCommandTest.java
@@ -206,6 +206,11 @@ public class AddPatientCommandTest {
         }
 
         @Override
+        public void deletePatientAppointments(Patient patient) {
+            throw new AssertionError("this method should not be called");
+        }
+
+        @Override
         public void setAppointment(Appointment target, Appointment editedAppointment) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/patient/DeletePatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/patient/DeletePatientCommandTest.java
@@ -31,7 +31,7 @@ public class DeletePatientCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Patient patientToDelete = model.getFilteredPatientList().get(INDEX_FIRST_IN_LIST.getZeroBased());
-        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(INDEX_FIRST_IN_LIST);
+        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(INDEX_FIRST_IN_LIST, false);
 
         String expectedMessage = String.format(Messages.MESSAGE_DELETE_PATIENT_SUCCESS, patientToDelete);
 
@@ -46,7 +46,7 @@ public class DeletePatientCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPatientList().size() + 1);
-        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(outOfBoundIndex);
+        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(outOfBoundIndex, false);
 
         assertCommandFailure(deletePatientCommand, model, Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
     }
@@ -56,7 +56,7 @@ public class DeletePatientCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_IN_LIST);
 
         Patient personToDelete = model.getFilteredPatientList().get(INDEX_FIRST_IN_LIST.getZeroBased());
-        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(INDEX_FIRST_IN_LIST);
+        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(INDEX_FIRST_IN_LIST, false);
 
         String expectedMessage = String.format(Messages.MESSAGE_DELETE_PATIENT_SUCCESS, personToDelete);
 
@@ -76,21 +76,21 @@ public class DeletePatientCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getPatientRecords().getPersonList().size());
 
-        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(outOfBoundIndex);
+        DeletePatientCommand deletePatientCommand = new DeletePatientCommand(outOfBoundIndex, false);
 
         assertCommandFailure(deletePatientCommand, model, Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeletePatientCommand deleteFirstCommand = new DeletePatientCommand(INDEX_FIRST_IN_LIST);
-        DeletePatientCommand deleteSecondCommand = new DeletePatientCommand(INDEX_SECOND_IN_LIST);
+        DeletePatientCommand deleteFirstCommand = new DeletePatientCommand(INDEX_FIRST_IN_LIST, false);
+        DeletePatientCommand deleteSecondCommand = new DeletePatientCommand(INDEX_SECOND_IN_LIST, false);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeletePatientCommand deleteFirstCommandCopy = new DeletePatientCommand(INDEX_FIRST_IN_LIST);
+        DeletePatientCommand deleteFirstCommandCopy = new DeletePatientCommand(INDEX_FIRST_IN_LIST, false);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/parser/UserInputParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UserInputParserTest.java
@@ -50,7 +50,7 @@ public class UserInputParserTest {
     public void parseCommand_delete() throws Exception {
         DeletePatientCommand command = (DeletePatientCommand) parser.parseCommand(
                 DeletePatientCommand.COMMAND_WORD + " " + INDEX_FIRST_IN_LIST.getOneBased());
-        assertEquals(new DeletePatientCommand(INDEX_FIRST_IN_LIST), command);
+        assertEquals(new DeletePatientCommand(INDEX_FIRST_IN_LIST, false), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/patient/DeletePatientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/patient/DeletePatientCommandParserTest.java
@@ -22,7 +22,7 @@ public class DeletePatientCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeletePatientCommand(INDEX_FIRST_IN_LIST));
+        assertParseSuccess(parser, "1", new DeletePatientCommand(INDEX_FIRST_IN_LIST, false));
     }
 
     @Test


### PR DESCRIPTION
Resolves second part of Issue #58

When `delete-patient --force` command is called on a patient with existing appointments in the Appointment Schedule, the appointments will be mass deleted, along with the patient.