### PR TITLE
feat: force delete of appointments in delete doctor command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -19,7 +19,7 @@ public class Messages {
                     + "Use the command \"clear-appt\" to clear the appointment schedule.";
     public static final String MESSAGE_DELETE_PATIENT_SUCCESS = "Deleted Patient: %1$s";
 
-    //==================================Doctor related messages===============================================
+    //=================================Doctor related messages================================================
     public static final String MESSAGE_DOCTORS_LISTED_OVERVIEW = "%1$d doctors listed!";
     public static final String MESSAGE_INVALID_DOCTOR_DISPLAYED_INDEX = "The doctor index provided is invalid";
     public static final String MESSAGE_FORCE_DELETE_DOCTOR_REQUIRED =

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -13,19 +13,22 @@ public class Messages {
     public static final String MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX = "The patient index provided is invalid";
     public static final String MESSAGE_FORCE_DELETE_PATIENT_REQUIRED =
             "The patient has existing appointments in appointment schedule."
-            + " Force delete command format required! \n%1$s";
-    public static final String MESSAGE_CLEAR_APPOINTMENTS_REQUIRED =
+                    + " Force delete command format required! \n%1$s";
+    public static final String MESSAGE_CLEAR_APPOINTMENTS_BEFORE_PATIENTS_REQUIRED =
             "Patient records cannot be cleared until appointment schedule is cleared.\n"
-            + "Use the command \"clear-appt\" to clear the appointment schedule.";
-    public static final String MESSAGE_DELETE_PATIENT_SUCCESS = "Deleted Person: %1$s";
+                    + "Use the command \"clear-appt\" to clear the appointment schedule.";
+    public static final String MESSAGE_DELETE_PATIENT_SUCCESS = "Deleted Patient: %1$s";
 
-    //=================================Doctor related messages===============================================
+    //==================================Doctor related messages===============================================
     public static final String MESSAGE_DOCTORS_LISTED_OVERVIEW = "%1$d doctors listed!";
     public static final String MESSAGE_INVALID_DOCTOR_DISPLAYED_INDEX = "The doctor index provided is invalid";
     public static final String MESSAGE_FORCE_DELETE_DOCTOR_REQUIRED =
             "The doctor has existing appointments in appointment schedule."
                     + " Force delete command format required! \n%1$s";
-    public static final String MESSAGE_DELETE_DOCTOR_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_CLEAR_APPOINTMENTS_BEFORE_DOCTORS_REQUIRED =
+            "Doctors records cannot be cleared until appointment schedule is cleared.\n"
+                    + "Use the command \"clear-appt\" to clear the appointment schedule.";
+    public static final String MESSAGE_DELETE_DOCTOR_SUCCESS = "Deleted Doctor: %1$s";
 
     //=================================Appointment related messages===========================================
     public static final String MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX =

--- a/src/main/java/seedu/address/logic/commands/doctor/ClearDoctorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/doctor/ClearDoctorCommand.java
@@ -3,14 +3,14 @@ package seedu.address.logic.commands.doctor;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_CLEAR_APPOINTMENTS_BEFORE_DOCTORS_REQUIRED;
 
+import java.util.List;
+
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.Doctor;
-
-import java.util.List;
 
 /**
  * Clears the address book.

--- a/src/main/java/seedu/address/logic/commands/doctor/ClearDoctorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/doctor/ClearDoctorCommand.java
@@ -1,11 +1,16 @@
 package seedu.address.logic.commands.doctor;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_CLEAR_APPOINTMENTS_BEFORE_DOCTORS_REQUIRED;
 
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.person.Doctor;
+
+import java.util.List;
 
 /**
  * Clears the address book.
@@ -17,8 +22,16 @@ public class ClearDoctorCommand extends Command {
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        List<Doctor> lastShownList = model.getFilteredDoctorList();
+        for (Doctor doctorToClear : lastShownList) {
+            if (model.hasDoctorInAppointmentSchedule(doctorToClear)) {
+                throw new CommandException(MESSAGE_CLEAR_APPOINTMENTS_BEFORE_DOCTORS_REQUIRED);
+            }
+        }
+
         model.setDoctorRecords(new AddressBook<>());
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/doctor/DeleteDoctorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/doctor/DeleteDoctorCommand.java
@@ -20,20 +20,27 @@ public class DeleteDoctorCommand extends Command {
     public static final String COMMAND_WORD = "delete-doctor";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
+            + ": Deletes the doctor identified by the index number used in the displayed doctor records.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String FORCE_DELETE_MESSAGE_USAGE = COMMAND_WORD + " --force"
-            + ": Deletes the person identified by the index number used in the displayed person list,\n"
+            + ": Deletes the doctor identified by the index number used in the displayed doctor records,\n"
             + "along with all the existing appointments associated with the person in the appointment schedule.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " --force " + " 1";
 
     private final Index targetIndex;
+    private final boolean isForceDelete;
 
-    public DeleteDoctorCommand(Index targetIndex) {
+    /**
+     * Constructor: creates a DeleteDoctorCommand
+     * @param targetIndex index of doctor to be deleted
+     * @param isForceDelete true if force delete is required
+     */
+    public DeleteDoctorCommand(Index targetIndex, boolean isForceDelete) {
         this.targetIndex = targetIndex;
+        this.isForceDelete = isForceDelete;
     }
 
     @Override
@@ -47,10 +54,14 @@ public class DeleteDoctorCommand extends Command {
 
         Doctor doctorToDelete = lastShownList.get(targetIndex.getZeroBased());
 
+        if (isForceDelete) {
+            model.deleteDoctorAppointments(doctorToDelete);
+        }
+
         // checks if doctor has any existing appointments
         if (model.hasDoctorInAppointmentSchedule(doctorToDelete)) {
             throw new CommandException(String.format(
-                    Messages.MESSAGE_FORCE_DELETE_PATIENT_REQUIRED, FORCE_DELETE_MESSAGE_USAGE));
+                    Messages.MESSAGE_FORCE_DELETE_DOCTOR_REQUIRED, FORCE_DELETE_MESSAGE_USAGE));
         }
 
         model.deleteDoctor(doctorToDelete);

--- a/src/main/java/seedu/address/logic/commands/patient/ClearPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/patient/ClearPatientCommand.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands.patient;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_CLEAR_APPOINTMENTS_REQUIRED;
+import static seedu.address.commons.core.Messages.MESSAGE_CLEAR_APPOINTMENTS_BEFORE_PATIENTS_REQUIRED;
 
 import java.util.List;
 
@@ -29,7 +29,7 @@ public class ClearPatientCommand extends Command {
         List<Patient> lastShownList = model.getFilteredPatientList();
         for (Patient patientToClear : lastShownList) {
             if (model.hasPatientInAppointmentSchedule(patientToClear)) {
-                throw new CommandException(MESSAGE_CLEAR_APPOINTMENTS_REQUIRED);
+                throw new CommandException(MESSAGE_CLEAR_APPOINTMENTS_BEFORE_PATIENTS_REQUIRED);
             }
         }
 

--- a/src/main/java/seedu/address/logic/commands/patient/DeletePatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/patient/DeletePatientCommand.java
@@ -20,13 +20,13 @@ public class DeletePatientCommand extends Command {
     public static final String COMMAND_WORD = "delete-patient";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
+            + ": Deletes the patient identified by the index number used in the displayed patient records.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String FORCE_DELETE_MESSAGE_USAGE = COMMAND_WORD + " --force"
-            + ": Deletes the person identified by the index number used in the displayed person list,\n"
-            + "along with all the existing appointments associated with the person in the appointment schedule.\n"
+            + ": Deletes the patient identified by the index number used in the displayed patient records,\n"
+            + "along with all the existing appointments associated with the patient in the appointment schedule.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " --force " + " 1";
 

--- a/src/main/java/seedu/address/logic/parser/doctor/DeleteDoctorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/doctor/DeleteDoctorCommandParser.java
@@ -17,7 +17,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class DeleteDoctorCommandParser implements Parser<DeleteDoctorCommand> {
 
     /**
-     * Used for the separation of force delete format and patient index from the format '--force INDEX'.
+     * Used for the separation of force delete format and doctor index from the format '--force INDEX'.
      */
     private static final Pattern FORCE_DELETE_FORMAT = Pattern.compile("(?<forceDelete>\\D+)(?<doctorIndex>.*)");
 

--- a/src/main/java/seedu/address/logic/parser/doctor/DeleteDoctorCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/doctor/DeleteDoctorCommandParser.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser.doctor;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.doctor.DeleteDoctorCommand;
 import seedu.address.logic.parser.Parser;
@@ -14,17 +17,40 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class DeleteDoctorCommandParser implements Parser<DeleteDoctorCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the DeleteDoctorCommand
+     * Used for the separation of force delete format and patient index from the format '--force INDEX'.
+     */
+    private static final Pattern FORCE_DELETE_FORMAT = Pattern.compile("(?<forceDelete>\\D+)(?<doctorIndex>.*)");
+
+    /**
+     * Parses the given {@code args} in the context of the DeleteDoctorCommand
      * and returns a DeleteDoctorCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteDoctorCommand parse(String args) throws ParseException {
+        final Matcher forceDeleteMatcher = FORCE_DELETE_FORMAT.matcher(args.trim());
+        boolean isForceDelete = false;
+        String indexToParse = args;
+
+        if (forceDeleteMatcher.matches()) {
+            final String forceDelete = forceDeleteMatcher.group("forceDelete").trim();
+            final String doctorIndex = forceDeleteMatcher.group("doctorIndex");
+
+            if (forceDelete.equals("--force")) {
+                isForceDelete = true;
+                indexToParse = doctorIndex;
+            }
+        }
+
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteDoctorCommand(index);
+            Index index = ParserUtil.parseIndex(indexToParse);
+
+            return new DeleteDoctorCommand(index, isForceDelete);
         } catch (ParseException pe) {
+            String messageUsage = isForceDelete ? DeleteDoctorCommand.FORCE_DELETE_MESSAGE_USAGE
+                    : DeleteDoctorCommand.MESSAGE_USAGE;
+
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteDoctorCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, messageUsage), pe);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/patient/DeletePatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/patient/DeletePatientCommandParser.java
@@ -17,12 +17,12 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class DeletePatientCommandParser implements Parser<DeletePatientCommand> {
 
     /**
-     * Used for the separation of force delete format and patient index.
+     * Used for the separation of force delete format and patient index from the format '--force INDEX'.
      */
     private static final Pattern FORCE_DELETE_FORMAT = Pattern.compile("(?<forceDelete>\\D+)(?<patientIndex>.*)");
 
     /**
-     * Parses the given {@code String} of arguments in the context of the DeletePatientCommand
+     * Parses the given {@code args} in the context of the DeletePatientCommand
      * and returns a DeletePatientCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
@@ -31,17 +31,17 @@ public class DeletePatientCommandParser implements Parser<DeletePatientCommand> 
         boolean isForceDelete = false;
         String indexToParse = args;
 
-        try {
-            if (forceDeleteMatcher.matches()) {
-                final String forceDelete = forceDeleteMatcher.group("forceDelete").trim();
-                final String patientIndex = forceDeleteMatcher.group("patientIndex");
+        if (forceDeleteMatcher.matches()) {
+            final String forceDelete = forceDeleteMatcher.group("forceDelete").trim();
+            final String patientIndex = forceDeleteMatcher.group("patientIndex");
 
-                if (forceDelete.equals("--force")) {
-                    isForceDelete = true;
-                    indexToParse = patientIndex;
-                }
+            if (forceDelete.equals("--force")) {
+                isForceDelete = true;
+                indexToParse = patientIndex;
             }
+        }
 
+        try {
             Index index = ParserUtil.parseIndex(indexToParse);
 
             return new DeletePatientCommand(index, isForceDelete);

--- a/src/main/java/seedu/address/model/AppointmentSchedule.java
+++ b/src/main/java/seedu/address/model/AppointmentSchedule.java
@@ -110,10 +110,17 @@ public class AppointmentSchedule implements ReadOnlyAppointmentSchedule {
     }
 
     /**
-     * Deletes all appointments associated with the input patient from the appointment schedule.
+     * Deletes all appointments associated with the input {@code patient} from the appointment schedule.
      */
     public void deletePatientAppointments(Patient patient) {
         appointments.deletePatientAppointments(patient);
+    }
+
+    /**
+     * Deletes all appointments associated with the input {@code doctor} from the appointment schedule.
+     */
+    public void deleteDoctorAppointments(Doctor doctor) {
+        appointments.deleteDoctorAppointments(doctor);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -185,15 +185,20 @@ public interface Model {
 
 
     /**
-     * Deletes the given appointment.
+     * Deletes the given appointment {@code target}.
      * The appointment must exist in the appointment schedule.
      */
     void deleteAppointment(Appointment target);
 
     /**
-     * Deletes all appointments associated with the input patient from the appointment schedule.
+     * Deletes all appointments associated with the input {@code patient} from the appointment schedule.
      */
     void deletePatientAppointments(Patient patient);
+
+    /**
+     * Deletes all appointments associated with the input {@code doctor} from the appointment schedule.
+     */
+    void deleteDoctorAppointments(Doctor doctor);
 
     /**
      * Adds the given appointment.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -260,6 +260,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void deleteDoctorAppointments(Doctor doctor) {
+        requireNonNull(doctor);
+        appointmentSchedule.deleteDoctorAppointments(doctor);
+    }
+
+    @Override
     public void addAppointment(Appointment appointment) {
         appointmentSchedule.addAppointment(appointment);
         updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);

--- a/src/main/java/seedu/address/model/appointment/NonConflictingAppointmentList.java
+++ b/src/main/java/seedu/address/model/appointment/NonConflictingAppointmentList.java
@@ -148,12 +148,21 @@ public class NonConflictingAppointmentList implements Iterable<Appointment> {
     }
 
     /**
-     * Deletes all appointments associated with the input patient from the appointment schedule.
+     * Deletes all appointments associated with the input {@code patient} from the appointment schedule.
      */
     public void deletePatientAppointments(Patient patient) {
         List<Appointment> patientAppointmentList = internalList.stream().filter(appointment ->
                 appointment.getPatient().equals(patient)).collect(Collectors.toList());
         patientAppointmentList.forEach(appointment -> internalList.remove(appointment));
+    }
+
+    /**
+     * Deletes all appointments associated with the input {@code doctor} from the appointment schedule.
+     */
+    public void deleteDoctorAppointments(Doctor doctor) {
+        List<Appointment> doctorAppointmentList = internalList.stream().filter(appointment ->
+                appointment.getDoctor().equals(doctor)).collect(Collectors.toList());
+        doctorAppointmentList.forEach(appointment -> internalList.remove(appointment));
     }
 
     public void setAppointments(NonConflictingAppointmentList replacement) {

--- a/src/test/java/seedu/address/logic/commands/doctor/ClearDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/doctor/ClearDoctorCommandTest.java
@@ -3,7 +3,10 @@ package seedu.address.logic.commands.doctor;
 import static seedu.address.commons.core.Messages.MESSAGE_CLEAR_APPOINTMENTS_BEFORE_PATIENTS_REQUIRED;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalAppObjects.*;
+import static seedu.address.testutil.TypicalAppObjects.getEmptyAppointmentSchedule;
+import static seedu.address.testutil.TypicalAppObjects.getTypicalAppointmentSchedule;
+import static seedu.address.testutil.TypicalAppObjects.getTypicalDoctorRecords;
+import static seedu.address.testutil.TypicalAppObjects.getTypicalPatientRecords;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/doctor/ClearDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/doctor/ClearDoctorCommandTest.java
@@ -1,13 +1,14 @@
 package seedu.address.logic.commands.doctor;
 
+import static seedu.address.commons.core.Messages.MESSAGE_CLEAR_APPOINTMENTS_BEFORE_PATIENTS_REQUIRED;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalAppObjects.getTypicalDoctorRecords;
-import static seedu.address.testutil.TypicalAppObjects.getTypicalPatientRecords;
+import static seedu.address.testutil.TypicalAppObjects.*;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.patient.ClearPatientCommand;
 import seedu.address.model.AddressBook;
-import seedu.address.model.AppointmentSchedule;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -23,15 +24,22 @@ public class ClearDoctorCommandTest {
     }
 
     @Test
-    public void execute_nonEmptyDoctorRecords_success() {
-        // empty appointment schedule to prevent conflict
+    public void execute_emptyAppointmentScheduleNonEmptyDoctorRecords_success() {
         Model model = new ModelManager(getTypicalPatientRecords(), getTypicalDoctorRecords(),
-                new AppointmentSchedule(), new UserPrefs());
+                getEmptyAppointmentSchedule(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalPatientRecords(), getTypicalDoctorRecords(),
-                new AppointmentSchedule(), new UserPrefs());
+                getEmptyAppointmentSchedule(), new UserPrefs());
 
-        expectedModel.setDoctorRecords(new AddressBook<>());
-        assertCommandSuccess(new ClearDoctorCommand(), model, ClearDoctorCommand.MESSAGE_SUCCESS, expectedModel);
+        expectedModel.setPatientRecords(new AddressBook<>());
+        assertCommandSuccess(new ClearPatientCommand(), model, ClearPatientCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_nonEmptyAppointmentScheduleNonEmptyDoctorRecords_failure() {
+        Model model = new ModelManager(getTypicalPatientRecords(), getTypicalDoctorRecords(),
+                getTypicalAppointmentSchedule(), new UserPrefs());
+
+        assertCommandFailure(new ClearPatientCommand(), model, MESSAGE_CLEAR_APPOINTMENTS_BEFORE_PATIENTS_REQUIRED);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/doctor/DeleteDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/doctor/DeleteDoctorCommandTest.java
@@ -33,7 +33,7 @@ public class DeleteDoctorCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Doctor doctorToDelete = model.getFilteredDoctorList().get(INDEX_FIRST_IN_LIST.getZeroBased());
-        DeleteDoctorCommand deleteDoctorCommand = new DeleteDoctorCommand(INDEX_FIRST_IN_LIST);
+        DeleteDoctorCommand deleteDoctorCommand = new DeleteDoctorCommand(INDEX_FIRST_IN_LIST, false);
 
         String expectedMessage = String.format(Messages.MESSAGE_DELETE_DOCTOR_SUCCESS, doctorToDelete);
 
@@ -51,7 +51,7 @@ public class DeleteDoctorCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredDoctorList().size() + 1);
-        DeleteDoctorCommand deleteDoctorCommand = new DeleteDoctorCommand(outOfBoundIndex);
+        DeleteDoctorCommand deleteDoctorCommand = new DeleteDoctorCommand(outOfBoundIndex, false);
 
         assertCommandFailure(deleteDoctorCommand, model, Messages.MESSAGE_INVALID_DOCTOR_DISPLAYED_INDEX);
     }
@@ -61,7 +61,7 @@ public class DeleteDoctorCommandTest {
         showDoctorAtIndex(model, INDEX_FIRST_IN_LIST);
 
         Doctor doctorToDelete = model.getFilteredDoctorList().get(INDEX_FIRST_IN_LIST.getZeroBased());
-        DeleteDoctorCommand deleteDoctorCommand = new DeleteDoctorCommand(INDEX_FIRST_IN_LIST);
+        DeleteDoctorCommand deleteDoctorCommand = new DeleteDoctorCommand(INDEX_FIRST_IN_LIST, false);
 
         String expectedMessage = String.format(Messages.MESSAGE_DELETE_DOCTOR_SUCCESS, doctorToDelete);
 
@@ -86,21 +86,21 @@ public class DeleteDoctorCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getDoctorRecords().getPersonList().size());
 
-        DeleteDoctorCommand deleteDoctorCommand = new DeleteDoctorCommand(outOfBoundIndex);
+        DeleteDoctorCommand deleteDoctorCommand = new DeleteDoctorCommand(outOfBoundIndex, false);
 
         assertCommandFailure(deleteDoctorCommand, model, Messages.MESSAGE_INVALID_DOCTOR_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteDoctorCommand deleteFirstCommand = new DeleteDoctorCommand(INDEX_FIRST_IN_LIST);
-        DeleteDoctorCommand deleteSecondCommand = new DeleteDoctorCommand(INDEX_SECOND_IN_LIST);
+        DeleteDoctorCommand deleteFirstCommand = new DeleteDoctorCommand(INDEX_FIRST_IN_LIST, false);
+        DeleteDoctorCommand deleteSecondCommand = new DeleteDoctorCommand(INDEX_SECOND_IN_LIST, false);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteDoctorCommand deleteFirstCommandCopy = new DeleteDoctorCommand(INDEX_FIRST_IN_LIST);
+        DeleteDoctorCommand deleteFirstCommandCopy = new DeleteDoctorCommand(INDEX_FIRST_IN_LIST, false);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/address/logic/commands/patient/ClearPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/patient/ClearPatientCommandTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.commands.patient;
 
-import static seedu.address.commons.core.Messages.MESSAGE_CLEAR_APPOINTMENTS_REQUIRED;
+import static seedu.address.commons.core.Messages.MESSAGE_CLEAR_APPOINTMENTS_BEFORE_PATIENTS_REQUIRED;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalAppObjects.getEmptyAppointmentSchedule;
@@ -26,7 +26,7 @@ public class ClearPatientCommandTest {
     }
 
     @Test
-    public void execute_nonEmptyPatientRecords_success() {
+    public void execute_emptyAppointmentScheduleNonEmptyPatientRecords_success() {
         Model model = new ModelManager(getTypicalPatientRecords(), getTypicalDoctorRecords(),
                 getEmptyAppointmentSchedule(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalPatientRecords(), getTypicalDoctorRecords(),
@@ -37,11 +37,11 @@ public class ClearPatientCommandTest {
     }
 
     @Test
-    public void execute_nonEmptyPatientRecords_failure() {
+    public void execute_nonEmptyAppointmentScheduleNonEmptyPatientRecords_failure() {
         Model model = new ModelManager(getTypicalPatientRecords(), getTypicalDoctorRecords(),
                 getTypicalAppointmentSchedule(), new UserPrefs());
 
-        assertCommandFailure(new ClearPatientCommand(), model, MESSAGE_CLEAR_APPOINTMENTS_REQUIRED);
+        assertCommandFailure(new ClearPatientCommand(), model, MESSAGE_CLEAR_APPOINTMENTS_BEFORE_PATIENTS_REQUIRED);
     }
 
 }

--- a/src/test/java/seedu/address/model/ModelStub.java
+++ b/src/test/java/seedu/address/model/ModelStub.java
@@ -185,6 +185,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void deleteDoctorAppointments(Doctor doctor) {
+        throw new AssertionError("This method should not be called");
+    }
+
+    @Override
     public void deleteAppointment(Appointment target) {
         throw new AssertionError("This method should not be called.");
     }


### PR DESCRIPTION
Resolves issue #75 

When `delete-doctor --force INDEX` command is called on a doctor with existing appointments in the Appointment Schedule, the appointments will be mass deleted, along with the doctor.