### PR TITLE
Issue Fix

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -236,7 +236,7 @@ Format: `add-appt pt/PATIENT_INDEX dr/DOCTOR_INDEX at/TIMESLOT_START [to/TIMESLO
 
 * The `TIMESLOT_START` and `TIMESLOT_END` must be either in a recognisable datetime format or prefixed with keyword `NEXT` followed by a datetime unit (DAY, MONTH, YEAR) or weekday (MONDAY, TUESDAY …​)<br>
 
-* Either and only one, `TIMESLOT_END` or `TIMESLOT_DURATION`, must be provided.<br>
+* Where both fields `TIMESLOT_END` and `TIMESLOT_DURATION` are provided, priority is granted to `TIMESLOT_END`.<br>
 
 * Raises an exception if there are conflicts in schedule for the patient or the doctor.<br>
 

--- a/src/main/java/seedu/address/logic/parser/appointment/EditAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/appointment/EditAppointmentCommandParser.java
@@ -56,16 +56,19 @@ public class EditAppointmentCommandParser implements Parser<EditAppointmentComma
                     .setDoctorIndex(ParserUtil.parseIndex(argMultimap.getValue(PREFIX_DOCTOR).get()));
         }
 
-        if (argMultimap.getValue(PREFIX_TIMESLOT_END).isPresent()) {
-            editAppointmentDescriptor.setTimeslot(TimeslotParser
-                    .parseTimeslotByEnd(argMultimap.getValue(PREFIX_TIMESLOT_START).get(),
-                    argMultimap.getValue(PREFIX_TIMESLOT_END).get()));
+        if (argMultimap.getValue(PREFIX_TIMESLOT_START).isPresent()) {
+            editAppointmentDescriptor
+                    .setStart(TimeslotParser.parseDateTime(argMultimap.getValue(PREFIX_TIMESLOT_START).get()));
         }
+
+        if (argMultimap.getValue(PREFIX_TIMESLOT_END).isPresent()) {
+            editAppointmentDescriptor
+                    .setEnd(TimeslotParser.parseDateTime(argMultimap.getValue(PREFIX_TIMESLOT_END).get()));
+        }
+
         if (argMultimap.getValue(PREFIX_TIMESLOT_DURATION).isPresent()) {
             editAppointmentDescriptor
-                    .setTimeslot(TimeslotParser
-                            .parseTimeslotByDuration(argMultimap.getValue(PREFIX_TIMESLOT_START).get(),
-                    argMultimap.getValue(PREFIX_TIMESLOT_DURATION).get()));
+                    .setDuration(TimeslotParser.parseDuration(argMultimap.getValue(PREFIX_TIMESLOT_DURATION).get()));
         }
 
         if (!editAppointmentDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/address/model/appointment/Timeslot.java
+++ b/src/main/java/seedu/address/model/appointment/Timeslot.java
@@ -71,15 +71,6 @@ public class Timeslot implements Comparable<Timeslot> {
     }
 
     //// Boolean Checks
-    /**
-     * Returns true if the dateTime {@code toCheck} lies within the timeslot period.
-     */
-    public boolean isBetween(LocalDateTime toCheck) {
-        assert toCheck != null : "the LocalDateTime provided should not be null";
-        return (toCheck.isBefore(getEnd()) || toCheck.isEqual(getEnd()))
-                && (toCheck.isAfter(getStart()) || toCheck.isEqual(getStart()));
-
-    }
 
     /**
      * Returns true if the timeslot {@code otherTimeslot} chronologically overlaps
@@ -87,7 +78,8 @@ public class Timeslot implements Comparable<Timeslot> {
      */
     public boolean hasOverlap(Timeslot otherTimeslot) {
         assert otherTimeslot != null : "the Timeslot provided should not be null";
-        return isBetween(otherTimeslot.getStart()) || isBetween(otherTimeslot.getEnd());
+
+        return start.isBefore(otherTimeslot.getEnd()) && end.isAfter(otherTimeslot.getStart());
     }
 
     @Override


### PR DESCRIPTION
** Changes **
* Changed EditAppointmentDescriptor to hold start, end and duration fields as the descriptor should only represent optional, non complex and independent fields. [ Fixes #116 ]
* Changed the criteria for Timeslot conflict [ Fixes #132 and #125 ]

** Testing **
* edit-appt taking in `at` field
![image](https://user-images.githubusercontent.com/59547181/113717151-e8c4f600-971d-11eb-82ad-6283ebaae922.png)
![image](https://user-images.githubusercontent.com/59547181/113717182-f11d3100-971d-11eb-8950-059c1dd41a90.png)

* edit-appt taking in `to` field
![image](https://user-images.githubusercontent.com/59547181/113717313-14e07700-971e-11eb-8d72-31ef08a9bd64.png)
![image](https://user-images.githubusercontent.com/59547181/113717364-2164cf80-971e-11eb-9d1b-0a52a3066681.png)

* edit-appt taking in `dur` field
![image](https://user-images.githubusercontent.com/59547181/113716772-83710500-971d-11eb-88df-742ae663a592.png)
![image](https://user-images.githubusercontent.com/59547181/113716871-98e62f00-971d-11eb-8080-b940528605ec.png)

* add-appt with existing appt from 2020-2022 (all conflicting)
![image](https://user-images.githubusercontent.com/59547181/113720818-9554a700-9721-11eb-9e7f-67b857cc8d97.png)

* add-appt with start time the same as existing appt end time
![image](https://user-images.githubusercontent.com/59547181/113721198-e4024100-9721-11eb-8df2-518b40e6168e.png)
![image](https://user-images.githubusercontent.com/59547181/113721243-ef556c80-9721-11eb-81fc-b37d4bb77315.png)

